### PR TITLE
Update CSS to only single column when only one category of articles

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ const HomePage = () => {
     <div className="dark:bg-neutral-900 bg-neutral-100 w-screen overflow-hidden">
       <section className="mx-auto w-11/12 md:w-6/8 lg:w-5/8 xl:w-1/2 mt-20 flex flex-col gap-16 mb-20 z-10">
         <Title />
-        <div className="-z-0 absolute right-1/8 top-1/4 lg:top-1/6 animate-appear-slow">
+        <div className="z-1 absolute right-1/8 top-1/4 lg:top-1/6 animate-appear-slow">
           <Splodge />
         </div>
         <div className="top-14/15 z-1 absolute left-1/8 lg:top-3/5 hidden lg:block animate-appear-slow">

--- a/components/HomePage/HomePageContent.tsx
+++ b/components/HomePage/HomePageContent.tsx
@@ -5,8 +5,11 @@ import Link from "next/link";
 
 const HomePageContent = () => {
   const articles = getAllArticles();
+  const cols = articles.length > 1 ? "md:grid-cols-2" : "md:grid-cols-1";
   return (
-    <section className="md:grid md:grid-cols-2 flex flex-col gap-15 lg:gap-10 z-2 animate-appear">
+    <section
+      className={`md:grid ${cols} flex flex-col gap-15 lg:gap-10 z-2 animate-appear`}
+    >
       {articles !== null &&
         articles.map((category: Category) => (
           <div


### PR DESCRIPTION
This pull request makes small improvements to the layout and responsiveness of the homepage components. The most notable changes are a fix to the z-index of a decorative element and a dynamic adjustment to the number of grid columns based on the number of articles.

**Homepage layout fixes:**

* Changed the z-index of the `Splodge` container from `-z-0` to `z-1` in `app/page.tsx` to ensure proper stacking order of elements.

**Responsive grid improvements:**

* Dynamically sets the number of grid columns in `HomePageContent` based on the number of articles, using one or two columns as appropriate, for better responsiveness in `components/HomePage/HomePageContent.tsx`.