### PR TITLE
Add permissions section to testing workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,5 +1,8 @@
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
This pull request introduces a small configuration update to the GitHub Actions workflow for Node.js CI. The change sets the workflow permissions to allow read-only access to repository contents.