### PR TITLE
Update body font to quicksand

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,7 +5,7 @@
 @theme {
   --font-title: "Jua";
   --font-titleDark: "Dreadful";
-  --font-body: "Poppins", sans-serif;
+  --font-body: "Quicksand", sans-serif;
   --font-body-bold: "Urbanist-600", sans-serif;
   --article: "article";
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Poppins, Jua } from "next/font/google";
+import { Jua, Quicksand } from "next/font/google";
 import localFont from "next/font/local";
 import "./globals.css";
 import { Providers } from "./providers";
@@ -13,10 +13,10 @@ const dreadful = localFont({
 });
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const poppins = Poppins({
+const quicksand = Quicksand({
   subsets: ["latin"],
-  variable: "--font-poppins",
-  weight: ["400", "600"],
+  variable: "--font-quicksand",
+  weight: ["400", "700"],
 });
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,20 +1,12 @@
-import type { Config } from "tailwindcss"
+import type { Config } from "tailwindcss";
 
 const config: Config = {
-    content: [
-        "./pages/**/*.{js,ts,jsx,tsx,mdx}",
-        "./components/**/*.{js,ts,jsx,tsx,mdx}",
-        "./app/**/*.{js,ts,jsx,tsx,mdx}",
-    ],
-    theme: {
-        extend: {
-            fontFamily: {
-                cormorantGaramond: ["var(--font-cormorant-garamond)", "serif"],
-                poppins: ["var(--font-poppins)", "sans-serif"],
-            },
-        }
-    },
-    plugins: [],
-}
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  plugins: [],
+};
 
-export default config
+export default config;


### PR DESCRIPTION
This pull request updates the project's primary body font from Poppins to Quicksand across the codebase, ensuring consistency in both CSS variables and font imports. It also removes the Poppins font configuration from the Tailwind setup to reflect this change.

Font update and configuration cleanup:

* Changed the body font CSS variable `--font-body` in `app/globals.css` from `"Poppins", sans-serif` to `"Quicksand", sans-serif`.
* Updated font imports in `app/layout.tsx` to use `Quicksand` instead of `Poppins`, and replaced the `poppins` font variable with `quicksand`. [[1]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL2-R2) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bL16-R19)
* Removed the Poppins font family configuration from `tailwind.config.ts`, eliminating `fontFamily.poppins` and related references.